### PR TITLE
"vcd_vm" Module Release 2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.tfstate.*
 secrets.tfvars
 secrets.auto.tfvars
+terraform.tfvars
+terraform.auto.tfvars
 providers.tf
 
 # Crash log files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VCD Virtual Machine Terraform Module
 
-This Terraform module will deploy "X" Number of Virtual Machines into an existing VMware Cloud Director (VCD) Environment.  This module can be used to provsion new Virtual Machines into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
+This Terraform module will deploy "X" Number of Virtual Machines into an existing VMware Cloud Director (VCD) Environment.  This module can be used to provision new Virtual Machines into [Rackspace Technology SDDC Flex](https://www.rackspace.com/cloud/private/software-defined-data-center-flex) VCD Data Center Regions.
 
 ## Requirements
 
@@ -88,7 +88,7 @@ The Terraform code example for the main.tf file is below:
 
 ```terraform
 module "vcd_vm" {
-  source                            = "github.com/global-vmware/vcd_vm.git?ref=v2.1.0"
+  source                            = "github.com/global-vmware/vcd_vm.git?ref=v2.1.1"
 
   vdc_org_name                      = "<US1-VDC-ORG-NAME>"
   vdc_group_name                    = "<US1-VDC-GRP-NAME>"

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ terraform {
 }
 
 data "vcd_vdc_group" "vdc_group" {
+  org       = var.vdc_org_name
   name      = var.vdc_group_name
 }
 
@@ -21,6 +22,7 @@ data "vcd_nsxt_edgegateway" "edge_gateway" {
 
 data "vcd_network_routed_v2" "segment" {
   for_each        = { for net in var.org_networks : net.name => net }
+  org             = var.vdc_org_name
   edge_gateway_id = data.vcd_nsxt_edgegateway.edge_gateway.id
   name            = each.value.name
 }
@@ -35,13 +37,15 @@ data "vcd_catalog" "catalog" {
 }
 
 data "vcd_catalog_vapp_template" "template" {
-  catalog_id = data.vcd_catalog.catalog.id
-  name       = var.catalog_template_name
+  org         = var.vdc_org_name
+  catalog_id  = data.vcd_catalog.catalog.id
+  name        = var.catalog_template_name
 }
 
 resource "vcd_vm" "vm" {
   for_each = { for i in range(var.vm_count) : i => i }
-
+  org                     = var.vdc_org_name
+  vdc                     = var.vdc_name
   name                    = var.vm_name_format != "" ? format(var.vm_name_format, var.vm_name[each.key % length(var.vm_name)], each.key + 1) : var.vm_name[each.key % length(var.vm_name)]
   computer_name           = var.computer_name_format != "" ? format(var.computer_name_format, var.computer_name[each.key % length(var.computer_name)], each.key + 1) : var.computer_name[each.key % length(var.computer_name)]
   vapp_template_id        = data.vcd_catalog_vapp_template.template.id


### PR DESCRIPTION
- "vcd_vm" Module Release 2.1.1

- Added the "org" Argument to the "vcd_vdc_group" Data Source

- Added the "org" Argument to the "vcd_network_routed_v2" Data Source

- Added the "org" Argument to the "vcd_catalog_vapp_template" Data Source

- Added the "org" Argument to the "vcd_vm" Resource

- Added the "vdc" Argument to the "vcd_vm" Resource

- Updated the source URL Reference in the "vcd_vm" Module Code Snippet to Version 2.1.1 in the Example Usage Section of the README