### PR TITLE
- "vcd_vm" Module Release 2.2.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,11 +28,12 @@ variable "vm_sizing_policy_name" {
 }
 
 variable "org_networks" {
-  description = "List of Org network names"
-  type        = list(object({
+  description = "List of Org networks with their types"
+  type = list(object({
     name = string
+    type = string
   }))
-  default     = []
+  default = []
 }
 
 variable "catalog_org_name" {


### PR DESCRIPTION
- Added the "vcd_network_isolated_v2" data source to dynamically choose routed or isolated networks based on the network type specified in org_networks variable

- Updated the "org_networks" variable to specify the network type for each org network

- Added the "adapter_type" attribute to the "vcd_vm" dynamic network block